### PR TITLE
Preventing flex-box's justifyContent values from being treated as operators

### DIFF
--- a/src/__tests__/value.test.js
+++ b/src/__tests__/value.test.js
@@ -25,6 +25,12 @@ describe('value', function() {
     expect(new Value(null, 'prop', varsArr).calc()).toEqual(null);
   });
 
+  it('should keep justifyContent values', function() {
+    ['flex-start', 'flex-end', 'space-around', 'space-between'].map((value) => {
+      expect(new Value(value, 'prop', varsArr).calc()).toEqual(value);
+    });
+  });
+
   it('should calc var', function() {
     expect(new Value('$a', 'prop', varsArr).calc()).toEqual(1);
     expect(new Value('$b', 'prop', varsArr).calc()).toEqual(2);
@@ -59,5 +65,4 @@ describe('value', function() {
     expect(new Value(() => 10, 'prop').calc()).toEqual(10);
     expect(new Value(() => '$a', 'prop', [{$a: 1}]).calc()).toEqual(1);
   });
-
 });

--- a/src/replacers/operation.js
+++ b/src/replacers/operation.js
@@ -9,6 +9,12 @@ const operators = {
   '-': (v1, v2) => v1 - v2,
 };
 
+/**
+ * Prevents flexbox's justifyContent values from being treated as operator
+ */
+
+const noops = ['flex-start', 'flex-end', 'space-around', 'space-between'];
+
 export default {
   isOperation,
   exec,
@@ -45,7 +51,9 @@ function exec(opInfo) {
 function findOperator(str) {
   for (let operator in operators) {
     let pos = str.indexOf(operator);
-    if (pos >= 0) {
+    let skip = noops.indexOf(str);
+
+    if (pos >= 0 && skip === -1) {
       return {operator, pos};
     }
   }


### PR DESCRIPTION

Hi, 

When I was using values for justifyContent that contains a dash character, e.g. 'flex-start', it was treated like an operation (minus operator), which in turn was throwing an exception ... 

This pull-request enables the isOperation method to return false, if one of those values is found. I don't know if my solution is the most clever one, because I'm relatively new to react-native and ES6 in general, but it works :)

What do you think?
