### PR TITLE
Handle object path for variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/vitalets/react-native-extended-stylesheet/issues"
   },
   "license": "MIT",
+  "dependencies": {
+    "object-resolve-path": "^1.1.0"
+  },
   "devDependencies": {
     "babel-eslint": "^6.0.2",
     "babel-jest": "^11.0.0",

--- a/src/replacers/__tests__/vars.test.js
+++ b/src/replacers/__tests__/vars.test.js
@@ -43,6 +43,37 @@ describe('vars', function () {
     expect(() => vars.get('abc')).toThrowError('You should pass vars array to vars.get()');
   });
 
+  it('should get object properties using path', function () {
+    const obj = {
+      $abc: {
+        foo: 'foo',
+        bar: {
+          color: '#FF',
+        },
+      },
+    };
+
+    expect(vars.get('$abc.foo', [obj])).toBe('foo');
+    expect(vars.get('$abc.bar.color', [obj])).toBe('#FF');
+    expect(vars.get('$abc.bar.color2', [obj])).toBe(undefined);
+  });
+
+  it('should get object array values using path', function () {
+    const obj = {
+      $abc: {
+        foo: [1, 2],
+        bar: [{
+          value: 'bar',
+        }],
+      },
+    };
+
+    expect(vars.get('$abc.foo[0]', [obj])).toBe(1);
+    expect(vars.get('$abc.bar[0].value', [obj])).toBe('bar');
+    expect(vars.get('$abc.foo[20]', [obj])).toBe(undefined);
+    expect(vars.get('$abc.unk[10]', [obj])).toBe(undefined);
+  });
+
   it('should add prefix', function () {
     let obj = {
       a: 1,

--- a/src/replacers/vars.js
+++ b/src/replacers/vars.js
@@ -68,7 +68,11 @@ function get(name, varsArr) {
       if (rootVar.length ===  name.length) {
         return vars[rootVar];
       } else {
-        return resolvePath({[rootVar]: vars[rootVar]}, name);
+        try {
+          return resolvePath({[rootVar]: vars[rootVar]}, name);
+        } catch (error) {
+          return undefined;
+        }
       }
     }
   }

--- a/src/replacers/vars.js
+++ b/src/replacers/vars.js
@@ -1,3 +1,4 @@
+import resolvePath from 'object-resolve-path';
 
 const PREFIX = '$';
 
@@ -57,11 +58,18 @@ function get(name, varsArr) {
   if (!Array.isArray(varsArr)) {
     throw new Error('You should pass vars array to vars.get()');
   }
+
+  const rootVar = name.match(/[^\.\[]*/)[0];
+
   // todo: use for.. of after https://github.com/facebook/react-native/issues/4676
   for (let i = 0; i < varsArr.length; i++) {
     let vars = varsArr[i];
-    if (vars && vars[name] !== undefined) {
-      return vars[name];
+    if (vars && vars[rootVar] !== undefined) {
+      if (rootVar.length ===  name.length) {
+        return vars[rootVar];
+      } else {
+        return resolvePath({[rootVar]: vars[rootVar]}, name);
+      }
     }
   }
 }

--- a/src/replacers/vars.js
+++ b/src/replacers/vars.js
@@ -60,20 +60,21 @@ function get(name, varsArr) {
   }
 
   const rootVar = name.match(/[^\.\[]*/)[0];
+  const isSimpleVar = rootVar === name;
 
   // todo: use for.. of after https://github.com/facebook/react-native/issues/4676
   for (let i = 0; i < varsArr.length; i++) {
     let vars = varsArr[i];
-    if (vars && vars[rootVar] !== undefined) {
-      if (rootVar.length ===  name.length) {
-        return vars[rootVar];
-      } else {
-        try {
-          return resolvePath({[rootVar]: vars[rootVar]}, name);
-        } catch (error) {
-          return undefined;
-        }
-      }
+    if (!vars || vars[rootVar] === undefined) {
+      continue;
+    }
+    if (isSimpleVar) {
+      return vars[name];
+    }
+    try {
+      return resolvePath({[rootVar]: vars[rootVar]}, name);
+    } catch (error) {
+      return undefined;
     }
   }
 }


### PR DESCRIPTION
This PR allows using object hierarchy and arrays in variables.

Examples:

```
EStyleSheet.build({
  var1: 'foo',
  color: {
    accent: '#0ff',
    random: ['red','yellow'],
  },
});
```

Then the following is possible and there is no limitation of nesting:
- As before: `$var1`
- Using object notation: `$color.accent`
- Using array notation: `$color.random[0]`

