### PR TITLE
Add division operator

### DIFF
--- a/src/replacers/__tests__/operation.test.js
+++ b/src/replacers/__tests__/operation.test.js
@@ -17,8 +17,13 @@ describe('operation', function () {
     expect(operation.isOperation('$abc-100%')).toEqual({operator: '-', v1: '$abc', v2: '100%'});
   });
 
+  it('should detect /', function () {
+    expect(operation.isOperation('10 / 20')).toEqual({operator: '/', v1: '10', v2: '20'});
+    expect(operation.isOperation('$abc/100%')).toEqual({operator: '/', v1: '$abc', v2: '100%'});
+  });
+
   it('should return false for non-operation', function () {
-    expect(operation.isOperation('$abc/100%')).toBe(false);
+    expect(operation.isOperation('$abc^100%')).toBe(false);
   });
 
   it('should exec *', function () {

--- a/src/replacers/__tests__/operation.test.js
+++ b/src/replacers/__tests__/operation.test.js
@@ -47,6 +47,8 @@ describe('operation', function () {
       .toThrowError('Unknown operator: a');
     expect(() => operation.exec({operator: '+', v1: '10', v2: 0.5}))
       .toThrowError('Operation value should be number, you try: 10');
+    expect(() => operation.exec({operator: '/', v1: 10, v2: 0}))
+      .toThrowError('Operation divisor should not be zero');
     expect(() => operation.exec({operator: '+', v1: 10, v2: null}))
       .toThrowError('Operation value should be number, you try: null');
   });

--- a/src/replacers/__tests__/operation.test.js
+++ b/src/replacers/__tests__/operation.test.js
@@ -38,6 +38,10 @@ describe('operation', function () {
     expect(operation.exec({operator: '-', v1: 10, v2: 0.5})).toBe(9.5);
   });
 
+  it('should exec /', function () {
+    expect(operation.exec({operator: '/', v1: 10, v2: 0.5})).toBe(20);
+  });
+
   it('should throw on invalid data', function () {
     expect(() => operation.exec({operator: 'a', v1: 10, v2: 0.5}))
       .toThrowError('Unknown operator: a');

--- a/src/replacers/operation.js
+++ b/src/replacers/operation.js
@@ -7,6 +7,7 @@ const operators = {
   '*': (v1, v2) => v1 * v2,
   '+': (v1, v2) => v1 + v2,
   '-': (v1, v2) => v1 - v2,
+  '/': (v1, v2) => v1 / v2,
 };
 
 export default {

--- a/src/replacers/operation.js
+++ b/src/replacers/operation.js
@@ -39,6 +39,9 @@ function exec(opInfo) {
   assertOperator(opInfo.operator);
   assertValue(opInfo.v1);
   assertValue(opInfo.v2);
+  if (opInfo.operator === '/') {
+    assertDivisor(opInfo.v2);
+  }
   let fn = operators[opInfo.operator];
   return fn(opInfo.v1, opInfo.v2);
 }
@@ -61,5 +64,11 @@ function assertOperator(operator) {
 function assertValue(value) {
   if (typeof value !== 'number') {
     throw new Error('Operation value should be number, you try: ' + value);
+  }
+}
+
+function assertDivisor(divisor) {
+  if (divisor === 0) {
+    throw new Error('Operation divisor should not be zero');
   }
 }


### PR DESCRIPTION
As mentioned earlier today in #37, division is currently not supported and probably should be. This PR adds the `/` operator so that we can math properly 😉 

fixes #37 