### PR TITLE
Updating position of child reference to allow CRA compile without plugins

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -12,8 +12,6 @@ import child from './child';
 const BUILD_EVENT = 'build';
 
 export default class {
-  child = child;
-
   /**
    * Constructor
    */
@@ -23,6 +21,7 @@ export default class {
     this.globalVars = null;
     this.listeners = {};
     this._proxyToOriginal();
+    this.child = child;
   }
 
   /**


### PR DESCRIPTION
Was receiving this error prior to updating the source:
```
Failed to compile.
./node_modules/react-native-extended-stylesheet/src/api.js
Module parse failed: /Volumes/HD/grant/Dev/_ct/mobile/node_modules/react-native-extended-stylesheet/src/api.js Unexpected token (15:8)
You may need an appropriate loader to handle this file type.
|
| export default class \{
|   child = child;
|
|   /**

```

Moving the declaration below into the constructor fixes this and tests pass. Correct me if I made any mistakes in relocating the placement of this parameter.

Thanks