### PR TITLE
Change README to fix incorrect REM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ const styles = EStyleSheet.create({
 // app entry
 let {height, width} = Dimensions.get('window');
 EStyleSheet.build({
-  rem: width > 340 ? 18 : 16
+  $rem: width > 340 ? 18 : 16
 });
 ```
 \[[top](#react-native-extended-stylesheet)\]


### PR DESCRIPTION
Currently the documentation omits the `$` from the `rem` variable which will result in an error. This PR just adds that in to make things clearer.