### PR TITLE
add test and support @media screen properties

### DIFF
--- a/src/replacers/__tests__/media-queries.test.js
+++ b/src/replacers/__tests__/media-queries.test.js
@@ -65,6 +65,21 @@ describe('media-queries', function () {
     expect(mq.process(obj)).toEqual({a: 1});
   });
 
+  it('should allow screen and media queries', function () {
+    const obj = {
+      a: 0,
+      '@media screen and (min-width: 50) and (max-width: 150)': {
+        a: 1,
+      },
+      '@media screen and (min-width: 150) and (max-width: 200)': {
+        a: 2,
+      }
+    };
+    const processed = mq.process(obj);
+    console.log('processed', processed);
+    expect(processed).toEqual({a: 1});
+  });
+
   it('should process height', function () {
     const obj = {
       '@media (min-height: 50) and (max-height: 150)': {
@@ -125,5 +140,4 @@ describe('media-queries', function () {
     };
     expect(mq.process(obj)).toEqual({a: 0});
   });
-
 });

--- a/src/replacers/media-queries.js
+++ b/src/replacers/media-queries.js
@@ -49,7 +49,7 @@ function process(obj) {
   if (mqKeys.length) {
     const matchObject = getMatchObject();
     mqKeys.forEach(key => {
-      const mqStr = key.replace(PREFIX, '');
+      const mqStr = key.replace(PREFIX, '').replace('screen', matchObject.type);
       const isMatch = mediaQuery.match(mqStr, matchObject);
       if (isMatch) {
         merge(res, obj[key]);


### PR DESCRIPTION
This adds support for the`screen` media type, next to all the `Platform.OS` types of React Native. This makes it easier for compatibility with converting browser CSS to React Native CSS with external libraries for example like Styled System / Emotion / Styled Components.

The current media query would work in the browser, but not using extended stylesheet:

**`@media screen and (min-width: 40rem)`**

This PR simply replaces the word `screen` with the current platform: `Platform.OS` to add support for media queries like this.

As an example, I'm using this library in my newly published [emotion-native-extended](https://github.com/ItsWendell/emotion-native-extended) which basically adds support for responsive CSS in JS as for React Native using Emotion and Extended Stylesheet. This allows for support for third party extensions for Styled Component / Emotion but these sometimes rely on 'browser' media queries, for example: Styled System.

Merging this PR might make it easier for browser people to integrate and use their styling for the native platform.