### PR TITLE
Improve intellisense for styles

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,22 +10,45 @@
  * Adding key augmention is tracked here: https://github.com/Microsoft/TypeScript/issues/12754
  */
 
-import {StyleSheet} from 'react-native';
+import {StyleSheet, ImageStyle, TextStyle, ViewStyle} from 'react-native';
 
 export = EStyleSheet;
 
 declare namespace EStyleSheet {
-    type AnyObject<T = {}> = T & {[key: string]: any};
     type Event = 'build';
 
+    type Function<K> = () => K
+    type Value<T> = T | string & {}
+    type Variable<T> = Value<T> | Function<Value<T>>
+    type Extended<T> = { [K in keyof T]: Variable<T[K]> }
 
-    export function create<T>(styles: AnyObject<T>): AnyObject<T>;
+    type AnyStyle = ImageStyle & TextStyle & ViewStyle
+    type AnyStyleSet = { [key: string]: AnyStyle }
+
+    type EStyleSet<T = any> = { [K in keyof T]:
+      T[K] extends Variable<number> ? T[K] :
+      T[K] extends MediaQuery ? T[K] :
+      Extended<AnyStyle> & EStyleSet
+    }
+
+    type StyleSet<T = any> = { [K in keyof T]:
+      T[K] extends number ? T[K] :
+      T[K] extends string ? T[K] :
+      T[K] extends Function<number> ? number :
+      T[K] extends Function<string> ? string :
+      T[K] extends MediaQuery ? any :
+      AnyStyle
+    }
+
+    export type MediaQuery = { [key: string]: Extended<AnyStyle> }
+
+    export function create<T = EStyleSet>(styles: EStyleSet<T>): StyleSet<T>;
     export function build<T>(rawGlobalVars?: T): void;
-    export function value<T>(expr: any, prop?: string): any;
+    export function value(expr: any, prop?: string): any;
     export function child<T>(styles: T, styleName: string, index: number, count: number): T;
     export function subscribe(event: Event, listener: () => any): void;
     export function clearCache(): void;
-  
+
     // inherited from StyleSheet
     export const flatten: typeof StyleSheet.flatten;
     export const setStyleAttributePreprocessor: typeof StyleSheet.setStyleAttributePreprocessor;
@@ -33,5 +56,3 @@ declare namespace EStyleSheet {
     export const absoluteFillObject: typeof StyleSheet.absoluteFillObject;
     export const absoluteFill: typeof StyleSheet.absoluteFill;
 }
-
-

--- a/types/test.ts
+++ b/types/test.ts
@@ -3,21 +3,25 @@
  */
 
 import {StyleSheet} from 'react-native';
-import EStyleSheet from '..';
+import EStyleSheet, {MediaQuery} from '..';
 
 const eStyles = EStyleSheet.create({
     $var: 10,
     button1: {
         width: () => '100%',
-        '@media (min-width: 350)': {
-            width: '$var'
-        }
+        height: 40,
+       '@media (min-width: 350)': {
+           width: '$var'
+        } as MediaQuery
+    },
+    button2: {
+        width: 200
     },
     '@media ios': {
-        button2: {
-            width: '100%',
+        button3: {
+            width: '100%'
         }
-    }
+    } as MediaQuery,
 });
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Improves the type declarations to provide some autocomplete when you define the styles and when you use them.

**Note: this will likely break code**
- The media-query definitions require `as MediaQuery`
- You won't be able to refer to styles created under a media-query

If we want to further improve this, I believe the media-query mechanism would require an overhaul. The stylesheet definition is so dynamic at this point, that it becomes very hard to instruct the TypeScript transcompiler on what's correct and what isn't.

See https://github.com/vitalets/react-native-extended-stylesheet/issues/118 for more information.