### PR TITLE
fix: type declaration error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,7 @@
 
 import {StyleSheet} from 'react-native';
 
-export = EStyleSheet;
+export default EStyleSheet;
 
 declare namespace EStyleSheet {
     type AnyObject<T = {}> = T & {[key: string]: any};
@@ -21,7 +21,7 @@ declare namespace EStyleSheet {
 
     export function create<T>(styles: AnyObject<T>): AnyObject<T>;
     export function build<T>(rawGlobalVars?: T): void;
-    export function value<T>(expr: any, prop?: string): any;
+    export function value<T>(expr: any, prop?: string): T;
     export function child<T>(styles: T, styleName: string, index: number, count: number): T;
     export function subscribe(event: Event, listener: () => any): void;
     export function clearCache(): void;


### PR DESCRIPTION
```ts
import EStyleSheet from 'react-native-extended-stylesheet'

EStyleSheet.value('$someVar')
```

When used with eslint-plugin-import, it prompts many questions, such as import/namespace, import/no-named-as-default, import/no-named-as-default-member.

If I use the following method, Babel will prompt an error.

```ts
import * as EStyleSheet from 'react-native-extended-stylesheet'

EStyleSheet.value('$someVar')
```

The `export default` export is used in `src/index.js`, I think the declaration should be changed.

The error message disappeared after I modified the local file.

At the same time, it can also be solved by overwriting the declaration.

> `export function value<T>(expr: any, prop?: string): T` T is right?

```ts
import type { StyleSheet } from 'react-native'

declare namespace EStyleSheet {
  type AnyObject<T = {}> = T & { [key: string]: any }
  type Event = 'build'

  export function create<T>(styles: AnyObject<T>): AnyObject<T>
  export function build<T>(rawGlobalVars?: T): void
  export function value<T>(expr: any, prop?: string): T
  export function child<T>(
    styles: T,
    styleName: string,
    index: number,
    count: number,
  ): T
  export function subscribe(event: Event, listener: () => any): void
  export function clearCache(): void

  // inherited from StyleSheet
  export const flatten: typeof StyleSheet.flatten
  export const setStyleAttributePreprocessor: typeof StyleSheet.setStyleAttributePreprocessor
  export const hairlineWidth: typeof StyleSheet.hairlineWidth
  export const absoluteFillObject: typeof StyleSheet.absoluteFillObject
  export const absoluteFill: typeof StyleSheet.absoluteFill
}

declare module 'react-native-extended-stylesheet' {
  export default EStyleSheet
}
```