### PR TITLE
Consider the "top", "left" and "right" props as being scalable

### DIFF
--- a/src/replacers/scale.js
+++ b/src/replacers/scale.js
@@ -5,10 +5,17 @@
 const SCALABLE_PROPS = [
   'width',
   'height',
+  'bottom',
   'margin',
   'padding',
   'fontsize',
   'radius',
+];
+
+const SCALABLE_PROPS_EXACT = [
+  'top',
+  'left',
+  'right',
 ];
 
 export default {
@@ -47,7 +54,8 @@ function isScalableProp(prop) {
     return false;
   }
   prop = prop.toLowerCase();
-  return SCALABLE_PROPS.some(p => {
+  return SCALABLE_PROPS_EXACT.includes(prop) || SCALABLE_PROPS.some(p => {
     return prop.indexOf(p) >= 0;
   });
 }
+


### PR DESCRIPTION
The 'scalability' of props was determined by checking if they have things like 'width', 'height', 'radius' in their name. This doesn't work for 'top', 'left' and 'right', and thus they weren't implemented in this manner. 
I added an exact match to make them work.